### PR TITLE
Expose NuGet.exe's NoDefaultExcludes option to prevent exclusion of files/folders starting with '.' (fixes #67).

### DIFF
--- a/src/NuProj.Targets/NuProj.props
+++ b/src/NuProj.Targets/NuProj.props
@@ -7,6 +7,7 @@
     <OutDir Condition=" '$(OutDir)' == ''" >$(MSBuildProjectDirectory)\bin\$(Configuration)\</OutDir>
     <IntermediateOutputPath Condition=" '$(IntermediateOutputPath)' == '' ">$(MSBuildProjectDirectory)\obj\$(Configuration)\</IntermediateOutputPath>
     <NoPackageAnalysis Condition=" '$(NoPackageAnalysis)' == '' ">False</NoPackageAnalysis>
+    <NoDefaultExcludes Condition=" '$(NoDefaultExcludes)' == '' ">False</NoDefaultExcludes>
     <GenerateSymbolPackage Condition=" '$(GenerateSymbolPackage)' == '' ">True</GenerateSymbolPackage>
     <EmbedSourceFiles Condition=" '$(EmbedSourceFiles)' == '' ">False</EmbedSourceFiles>
     <RequireLicenseAcceptance Condition=" '$(RequireLicenseAcceptance)' == '' ">False</RequireLicenseAcceptance>

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -448,6 +448,7 @@
              Condition="!Exists('$(OutDir)')" />
     <NuGetPack OutputDirectory="$(OutDir)"
                NoPackageAnalysis="$(NoPackageAnalysis)"
+               NoDefaultExcludes="$(NoDefaultExcludes)"
                Symbols="$(GenerateSymbolPackage)"
                ToolPath="$(NuGetToolPath)"
                ToolExe="$(NuGetToolExe)"

--- a/src/NuProj.Tasks/NuGetPack.cs
+++ b/src/NuProj.Tasks/NuGetPack.cs
@@ -17,6 +17,8 @@ namespace NuProj.Tasks
 
         public bool NoPackageAnalysis { get; set; }
 
+        public bool NoDefaultExcludes { get; set; }
+
         public bool ExcludeEmptyDirectories { get; set; }
 
         protected override string ToolName
@@ -41,6 +43,9 @@ namespace NuProj.Tasks
 
             if (NoPackageAnalysis)
                 builder.AppendSwitch("-NoPackageAnalysis");
+
+            if (NoDefaultExcludes)
+                builder.AppendSwitch("-NoDefaultExcludes");
 
             if (ExcludeEmptyDirectories)
                 builder.AppendSwitch("-ExcludeEmptyDirectories");


### PR DESCRIPTION
Per email, I've implemented this in the same manner as the existing NoPackageAnalysis property/parameter.